### PR TITLE
Allow to pass object name symbol to enumerated_attribute method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,22 @@
 PATH
   remote: .
   specs:
-    galetahub-enum_field (0.5.0)
+    galetahub-enum_field (0.5.2)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.2)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
-    i18n (0.8.1)
-    minitest (5.10.1)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -31,7 +32,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -44,4 +45,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/lib/enum_field.rb
+++ b/lib/enum_field.rb
@@ -15,6 +15,7 @@
 module EnumField
   autoload :DefineEnum, 'enum_field/define_enum'
   autoload :Builder, 'enum_field/builder'
+  autoload :AttributeValueResolver, 'enum_field/attribute_value_resolver'
   autoload :EnumeratedAttribute, 'enum_field/enumerated_attribute'
   autoload :Version, 'enum_field/version'
 

--- a/lib/enum_field/attribute_value_resolver.rb
+++ b/lib/enum_field/attribute_value_resolver.rb
@@ -1,0 +1,31 @@
+module EnumField
+  class AttributeValueResolver
+    attr_reader :value, :klass
+
+    def initialize(value, klass)
+      @value = value
+      @klass = klass
+    end
+
+    def resolve
+      if value_is_member?
+        value.id
+      elsif value_is_member_name?
+        klass.send(value).id
+      end
+    end
+
+    private
+
+    def value_is_member?
+      value && value.respond_to?(:id)
+    end
+
+    def value_is_member_name?
+      return false unless value.is_a?(Symbol)
+      return true if klass.respond_to?(value)
+
+      raise EnumField::ObjectNotFound, value
+    end
+  end
+end

--- a/lib/enum_field/enumerated_attribute.rb
+++ b/lib/enum_field/enumerated_attribute.rb
@@ -54,7 +54,7 @@ module EnumField
       end
 
       define_method("#{name_attribute}=") do |value|
-        raw = value ? value.id : nil
+        raw = EnumField::AttributeValueResolver.new(value, klass).resolve
         send("#{id_attribute}=", raw)
       end
     end

--- a/spec/enum_field/attribute_value_resolver_spec.rb
+++ b/spec/enum_field/attribute_value_resolver_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe EnumField::AttributeValueResolver do
+  # Sample ruby class
+  class Role
+    include EnumField::DefineEnum
+
+    define_enum do
+      member :admin
+      member :manager
+      member :employee
+    end
+  end
+
+  it 'should find object by member name and return id' do
+    expect(described_class.new(:admin, Role).resolve).to eq 1
+    expect(described_class.new(:manager, Role).resolve).to eq 2
+    expect(described_class.new(:employee, Role).resolve).to eq 3
+  end
+
+  it 'should raise error on invalid member name' do
+    expect { described_class.new(:invalid_member_name, Role).resolve }
+      .to raise_error(EnumField::ObjectNotFound)
+  end
+
+  it 'should return member id' do
+    expect(described_class.new(Role.admin, Role).resolve).to eq 1
+    expect(described_class.new(Role.manager, Role).resolve).to eq 2
+    expect(described_class.new(Role.employee, Role).resolve).to eq 3
+  end
+end


### PR DESCRIPTION
This change allows passing the object name instead of the full class name. Sample:

```ruby
class Role
  define_enum do
    member :admin
  end
end

class User < ApplicationRecord
  extend EnumField::EnumeratedAttribute

  enumerated_attribute :role
end
```

Now you can create user with `User.create(role: :admin)` intead of `User.create(role: Role.admin)`